### PR TITLE
Add support for subscription key parameter in GraphQL requests 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:16-alpine3.16
-LABEL maintainer="Digitransit <digitrtransit@hsl.fi>"
+LABEL maintainer="Digitransit <digitransit@HSL.fi>"
 
 WORKDIR /opt/digitransit-graphql
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ COPY . ./
 RUN yarn
 
 EXPOSE 8080
+ENV REACT_APP_DISABLE_LIVE_RELOAD=true
 ENTRYPOINT ["yarn", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,10 @@
-FROM node:16-alpine3.16 as build
+FROM node:16-alpine3.16
 LABEL maintainer="Digitransit <digitrtransit@hsl.fi>"
 
 WORKDIR /opt/digitransit-graphql
 
 COPY . ./
-RUN yarn && yarn build
+RUN yarn
 
-FROM node:16-alpine3.16
-WORKDIR /app
-COPY --from=build /opt/digitransit-graphql/run.sh ./
-COPY --from=build /opt/digitransit-graphql/build ./
-COPY --from=build /opt/digitransit-graphql/serve.json ./
-RUN yarn global add serve@14.x
 EXPOSE 8080
-ENTRYPOINT ["./run.sh"]
+ENTRYPOINT ["yarn", "start"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 Deployment for HSL version of [GraphiQL](https://github.com/graphql/graphiql). Production deployment available from https://api.digitransit.fi/graphiql/hsl
 
+## Start server
+
+```sh
+REACT_APP_API_SUBSCRIPTION_KEY=key yarn start
+```
+
+Environment variable `REACT_APP_API_SUBSCRIPTION_KEY` is set for *Azure API Management* authorization.
+
+
 ## Code formatting
 
 Format source codebase:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Deployment for HSL version of [GraphiQL](https://github.com/graphql/graphiql). P
 REACT_APP_API_SUBSCRIPTION_KEY=key REACT_APP_API_SUBSCRIPTION_KEY_PARAM=digitransit-subscription-key yarn start
 ```
 
-Environment variable `REACT_APP_API_SUBSCRIPTION_KEY` and `REACT_APP_API_SUBSCRIPTION_KEY_PARAM` are set for _Azure API Management_ authorization.
+Environment variable `REACT_APP_API_SUBSCRIPTION_KEY` and `REACT_APP_API_SUBSCRIPTION_KEY_PARAM` are set to GraphQL request query string for authorization gateway service.
 
 ## Run in docker
 
@@ -18,7 +18,7 @@ docker run -it \
     -p 8099:8080 \
     -e REACT_APP_API_SUBSCRIPTION_KEY=test \
     -e REACT_APP_API_SUBSCRIPTION_KEY_PARAM=digitransit-subscription-key \
-     digitransit-graphiql
+     graphiql
 ```
 
 ## Code formatting

--- a/README.md
+++ b/README.md
@@ -5,11 +5,21 @@ Deployment for HSL version of [GraphiQL](https://github.com/graphql/graphiql). P
 ## Start server
 
 ```sh
-REACT_APP_API_SUBSCRIPTION_KEY=key yarn start
+REACT_APP_API_SUBSCRIPTION_KEY=key REACT_APP_API_SUBSCRIPTION_KEY_PARAM=digitransit-subscription-key yarn start
 ```
 
-Environment variable `REACT_APP_API_SUBSCRIPTION_KEY` is set for *Azure API Management* authorization.
+Environment variable `REACT_APP_API_SUBSCRIPTION_KEY` and `REACT_APP_API_SUBSCRIPTION_KEY_PARAM` are set for _Azure API Management_ authorization.
 
+## Run in docker
+
+```sh
+docker build -t graphiql
+docker run -it \
+    -p 8099:8080 \
+    -e REACT_APP_API_SUBSCRIPTION_KEY=test \
+    -e REACT_APP_API_SUBSCRIPTION_KEY_PARAM=digitransit-subscription-key \
+     digitransit-graphiql
+```
 
 ## Code formatting
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "graphiql": "^1.11.4",
     "graphql": "^16.5.0",
-    "graphql-ws": "^5.9.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-router-dom": "^5.0.0",
@@ -41,6 +40,7 @@
   },
   "devDependencies": {
     "eslint": "^8.19.0",
-    "eslint-config-react-app": "^7.0.1"
+    "eslint-config-react-app": "^7.0.1",
+    "graphql-ws": "^5.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --watchAll=false",
+    "test": "react-scripts test --watchAll=false --coverage",
     "test:watch": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint src/**/*.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphiql-deployment",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "engines": {
     "node": ">=16.16.0 <17.0.0"
   },
@@ -16,7 +16,7 @@
     "react-scripts": "^5.0.0"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "PORT=8080 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --watchAll=false --coverage",
     "test:watch": "react-scripts test",

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,23 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>GraphiQL</title>
+    <% if (process.env.REACT_APP_DISABLE_LIVE_RELOAD === "true") { %>
+    <!--
+      Disable devserver Live Reload it by starting the app with REACT_APP_DISABLE_LIVE_RELOAD=true
+    -->
+    <script>
+      var WS = window.WebSocket;
+      function DevWebSocket(s) {
+        if (s === 'ws://localhost:8080/ws') {
+          return {};
+        } else {
+          // Pass through other usage of sockets
+          return new WS(s);
+        }
+      }
+      window.WebSocket = DevWebSocket;
+    </script>
+    <% } %>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-mkdir graphiql
-ln -s $(pwd)/static/ graphiql/static
-
-serve -l 8080 -s

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -2,8 +2,25 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 
+const initWindowLocation = (window, url) => {
+  const location = new URL(url);
+  location.assign = jest.fn();
+  location.replace = jest.fn();
+  location.reload = jest.fn();
+
+  delete window.location;
+  window.location = location;
+};
+
 describe('App', () => {
-  it('should render without crashing', () => {
+  test('renders basepath without crashing', () => {
+    initWindowLocation(window, 'https://localhost/graphiql');
+    const div = document.createElement('div');
+    ReactDOM.render(<App />, div);
+  });
+
+  test('renders end-point "hsl" without crashing', () => {
+    initWindowLocation(window, 'https://localhost/graphiql/hsl?query=%257Bfeeds%257BfeedId%257D%257D');
     const div = document.createElement('div');
     ReactDOM.render(<App />, div);
   });

--- a/src/GraphiQL.js
+++ b/src/GraphiQL.js
@@ -6,18 +6,12 @@ import { usePrettifyEditors, useHistoryContext } from '@graphiql/react';
 import 'graphiql/graphiql.css';
 
 import './fix.css';
+import graphQLFetcher from './api/graphQLFetcher';
 
 const API_TYPES = {
   prod: { label: 'Production' },
   dev: { label: 'Development' }
 };
-
-const graphQLFetcher = (apiUrl) => (graphQLParams) =>
-  fetch(apiUrl, {
-    method: 'post',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(graphQLParams)
-  }).then((response) => response.json());
 
 const areConfigsEqual = (config1, config2) => {
   return config1.router === config2.router &&

--- a/src/GraphiQL.js
+++ b/src/GraphiQL.js
@@ -156,7 +156,9 @@ const CustomGraphiQLWrapper = ({
   push,
   configs,
   config,
-  replace
+  replace,
+  subscriptionKey,
+  subscriptionKeyParam
 }) => {
   const [query, setQuery] = useState();
   const [variables, setVariables] = useState();
@@ -226,7 +228,9 @@ const CustomGraphiQLWrapper = ({
       apiType={apiType}
       config={config}
       configs={configs}
-      graphQLFetcher={graphQLFetcher}
+      graphQLFetcher={(apiUrl) =>
+        graphQLFetcher(apiUrl, subscriptionKey, subscriptionKeyParam)
+      }
       hasRoute={hasRoute}
       onSelectApi={onSelectApi}
       operationName={operationName}
@@ -240,23 +244,46 @@ const CustomGraphiQLWrapper = ({
   );
 };
 
-const GraphiQLRoute = withRouter(
-  ({ location, history, configs, config, isDefault = false }) => (
-    <Route
-      path={isDefault ? '/' + config.router : `/${config.router}/${config.api}`}
-      exact
-      render={() => (
-        <>
-          <CustomGraphiQLWrapper
-            location={location}
-            push={history.push}
-            replace={history.replace}
-            configs={configs}
-            config={config}
-          />
-        </>
-      )}
+const withSubscriptionKey = (Component) => (props) =>
+  (
+    <Component
+      {...props}
+      subscriptionKey={process.env.REACT_APP_API_SUBSCRIPTION_KEY}
+      subscriptionKeyParam={process.env.REACT_APP_API_SUBSCRIPTION_KEY_PARAM}
     />
+  );
+
+const GraphiQLRoute = withSubscriptionKey(
+  withRouter(
+    ({
+      location,
+      history,
+      configs,
+      config,
+      isDefault = false,
+      subscriptionKey = null,
+      subscriptionKeyParam = null
+    }) => (
+      <Route
+        path={
+          isDefault ? '/' + config.router : `/${config.router}/${config.api}`
+        }
+        exact
+        render={() => (
+          <>
+            <CustomGraphiQLWrapper
+              location={location}
+              push={history.push}
+              replace={history.replace}
+              configs={configs}
+              config={config}
+              subscriptionKey={subscriptionKey}
+              subscriptionKeyParam={subscriptionKeyParam}
+            />
+          </>
+        )}
+      />
+    )
   )
 );
 

--- a/src/api/graphQLFetcher.js
+++ b/src/api/graphQLFetcher.js
@@ -3,11 +3,7 @@ export const buildHeaders = (headers) => ({
   'Content-Type': 'application/json'
 });
 
-export const addSubscriptionKey = (
-  apiUrl,
-  key,
-  keyParam = 'subscription-key'
-) => {
+export const addSubscriptionKey = (apiUrl, key, keyParam) => {
   const url = new URL(apiUrl);
   if (key && keyParam) {
     url.searchParams.set(keyParam, key);
@@ -23,7 +19,11 @@ export const buildRequest = (
   headers
 ) =>
   new Request(
-    addSubscriptionKey(apiUrl, subscriptionKey, subscriptionKeyParam),
+    addSubscriptionKey(
+      apiUrl,
+      subscriptionKey,
+      subscriptionKeyParam || 'subscription-key'
+    ),
     {
       method: 'post',
       headers: buildHeaders(headers),

--- a/src/api/graphQLFetcher.js
+++ b/src/api/graphQLFetcher.js
@@ -3,10 +3,18 @@ export const buildHeaders = (headers) => ({
   'Content-Type': 'application/json'
 });
 
+const addSubscriptionKey = (apiUrl, key, keyParam = 'subscription-key') => {
+  const url = new URL(apiUrl);
+  if (key && keyParam) {
+    url.searchParams.set(keyParam, key);
+  }
+  return url;
+};
+
 const graphQLFetcher =
-  (apiUrl) =>
+  (apiUrl, subscriptionKey, subscriptionKeyParam = 'subscription-key') =>
   (graphQLParams, headers = null) =>
-    fetch(apiUrl, {
+    fetch(addSubscriptionKey(apiUrl, subscriptionKey, subscriptionKeyParam), {
       method: 'post',
       headers: buildHeaders(headers),
       body: JSON.stringify(graphQLParams)

--- a/src/api/graphQLFetcher.js
+++ b/src/api/graphQLFetcher.js
@@ -3,7 +3,11 @@ export const buildHeaders = (headers) => ({
   'Content-Type': 'application/json'
 });
 
-const addSubscriptionKey = (apiUrl, key, keyParam = 'subscription-key') => {
+export const addSubscriptionKey = (
+  apiUrl,
+  key,
+  keyParam = 'subscription-key'
+) => {
   const url = new URL(apiUrl);
   if (key && keyParam) {
     url.searchParams.set(keyParam, key);
@@ -11,13 +15,33 @@ const addSubscriptionKey = (apiUrl, key, keyParam = 'subscription-key') => {
   return url;
 };
 
-const graphQLFetcher =
-  (apiUrl, subscriptionKey, subscriptionKeyParam = 'subscription-key') =>
-  (graphQLParams, headers = null) =>
-    fetch(addSubscriptionKey(apiUrl, subscriptionKey, subscriptionKeyParam), {
+export const buildRequest = (
+  apiUrl,
+  subscriptionKey,
+  subscriptionKeyParam,
+  graphQLParams,
+  headers
+) =>
+  new Request(
+    addSubscriptionKey(apiUrl, subscriptionKey, subscriptionKeyParam),
+    {
       method: 'post',
       headers: buildHeaders(headers),
       body: JSON.stringify(graphQLParams)
-    }).then((response) => response.json());
+    }
+  );
+
+const graphQLFetcher =
+  (apiUrl, subscriptionKey, subscriptionKeyParam = 'subscription-key') =>
+  (graphQLParams, headers = null) =>
+    fetch(
+      buildRequest(
+        apiUrl,
+        subscriptionKey,
+        subscriptionKeyParam,
+        graphQLParams,
+        headers
+      )
+    ).then((response) => response.json());
 
 export default graphQLFetcher;

--- a/src/api/graphQLFetcher.js
+++ b/src/api/graphQLFetcher.js
@@ -1,0 +1,15 @@
+export const buildHeaders = (headers) => ({
+  ...(headers instanceof Object ? headers : {}),
+  'Content-Type': 'application/json'
+});
+
+const graphQLFetcher =
+  (apiUrl) =>
+  (graphQLParams, headers = null) =>
+    fetch(apiUrl, {
+      method: 'post',
+      headers: buildHeaders(headers),
+      body: JSON.stringify(graphQLParams)
+    }).then((response) => response.json());
+
+export default graphQLFetcher;

--- a/src/api/graphQLFetcher.test.js
+++ b/src/api/graphQLFetcher.test.js
@@ -22,7 +22,8 @@ describe('graphQLFetcher', () => {
     it('should set URL subscription key', () => {
       const url = addSubscriptionKey(
         'https://api.example.com/graphql',
-        'secret1'
+        'secret1',
+        'subscription-key'
       );
       expect(url.pathname).toEqual('/graphql');
       expect(url.searchParams.get('subscription-key')).toEqual('secret1');
@@ -31,7 +32,8 @@ describe('graphQLFetcher', () => {
     it('should add subscription key to URL without removing existing query params', () => {
       const url = addSubscriptionKey(
         'https://api.example.com/graphql?query=my-graphql-query',
-        'secret1'
+        'secret1',
+        'subscription-key'
       );
       expect(url.pathname).toEqual('/graphql');
       expect(url.searchParams.get('query')).toEqual('my-graphql-query');

--- a/src/api/graphQLFetcher.test.js
+++ b/src/api/graphQLFetcher.test.js
@@ -1,4 +1,8 @@
-import { buildHeaders } from './graphQLFetcher';
+import {
+  addSubscriptionKey,
+  buildHeaders,
+  buildRequest
+} from './graphQLFetcher';
 
 describe('graphQLFetcher', () => {
   describe('buildHeaders', () => {
@@ -11,6 +15,43 @@ describe('graphQLFetcher', () => {
     it('should return standard headers', () => {
       const headers = buildHeaders();
       expect(headers['Content-Type']).toBeTruthy();
+    });
+  });
+
+  describe('addSubscriptionKey', () => {
+    it('should set URL subscription key', () => {
+      const url = addSubscriptionKey(
+        'https://api.example.com/graphql',
+        'secret1'
+      );
+      expect(url.pathname).toEqual('/graphql');
+      expect(url.searchParams.get('subscription-key')).toEqual('secret1');
+    });
+
+    it('should add subscription key to URL without removing existing query params', () => {
+      const url = addSubscriptionKey(
+        'https://api.example.com/graphql?query=my-graphql-query',
+        'secret1'
+      );
+      expect(url.pathname).toEqual('/graphql');
+      expect(url.searchParams.get('query')).toEqual('my-graphql-query');
+      expect(url.searchParams.get('subscription-key')).toEqual('secret1');
+    });
+  });
+
+  describe('buildRequest', () => {
+    it('should build valid Request object', () => {
+      const req = buildRequest(
+        'https://api.example.com/graphql',
+        'secret1',
+        'subscription-key',
+        '{feed{feedId}}'
+      );
+      expect(req instanceof Request).toBeTruthy();
+      expect(req.method).toEqual('POST');
+      expect(req.url).toEqual(
+        'https://api.example.com/graphql?subscription-key=secret1'
+      );
     });
   });
 });

--- a/src/api/graphQLFetcher.test.js
+++ b/src/api/graphQLFetcher.test.js
@@ -1,0 +1,16 @@
+import { buildHeaders } from './graphQLFetcher';
+
+describe('graphQLFetcher', () => {
+  describe('buildHeaders', () => {
+    it('should return headers with custom header', () => {
+      const headers = buildHeaders({ 'X-ExtraHeader': 'abc' });
+      expect(headers['X-ExtraHeader']).toEqual('abc');
+      expect(headers['Content-Type']).toBeTruthy();
+    });
+
+    it('should return standard headers', () => {
+      const headers = buildHeaders();
+      expect(headers['Content-Type']).toBeTruthy();
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4497,9 +4497,9 @@ graphql-language-service@^5.0.6:
     vscode-languageserver-types "^3.15.1"
 
 graphql-ws@^5.9.1:
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.10.0.tgz#3fb47a4e809e0d2e7c197f1bca754fa9f31b940e"
-  integrity sha512-ewbPzHQdRZgNCPDH9Yr6xccSeZfk3fmpO/AGGGg4KkM5gc6oAOJQ10Oui1EqprhVOyRbOll9bw2qAkOiOwfTag==
+  version "5.10.1"
+  resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.10.1.tgz#c5402a62f1be13e244ab90a6306b94f643577312"
+  integrity sha512-MKm/3SRd1vj5Km8NaujsgeGRTKZQjUN5HRnIMJ8dL2UznKoxvrtQyJqTmqJt0f6vQd9AooDg/+baXo3huiY4Ew==
 
 graphql@^16.5.0:
   version "16.5.0"


### PR DESCRIPTION
**Changes**
 - Add query params from env variables `REACT_APP_API_SUBSCRIPTION_KEY` and `REACT_APP_API_SUBSCRIPTION_KEY_PARAM` to graphql request to enable API Management authentication.
 - Start graphiql service as a server (development).

**Next**
 - Subscription keys for dev and prod environments should be configured in project _digitransit-kubernetes-deploy_ branch https://github.com/HSLdevcom/digitransit-kubernetes-deploy/tree/DT-5476_graphiql-envs

Depends on: PR https://github.com/HSLdevcom/graphiql-deployment/pull/49 (pending dependency package version bump)
Related issue: DT-5476