### PR TITLE
prod key env, redirection to hsl, readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,19 @@ Deployment for HSL version of [GraphiQL](https://github.com/graphql/graphiql). P
 ## Start server
 
 ```sh
-REACT_APP_API_SUBSCRIPTION_KEY=key REACT_APP_API_SUBSCRIPTION_KEY_PARAM=digitransit-subscription-key yarn start
+REACT_APP_DEV_API_SUBSCRIPTION_KEY=key REACT_APP_API_SUBSCRIPTION_KEY=key REACT_APP_API_SUBSCRIPTION_KEY_PARAM=digitransit-subscription-key yarn start
 ```
 
-Environment variable `REACT_APP_API_SUBSCRIPTION_KEY` and `REACT_APP_API_SUBSCRIPTION_KEY_PARAM` are set to GraphQL request query string for authorization gateway service.
+Environment variables `REACT_APP_DEV_API_SUBSCRIPTION_KEY`, `REACT_APP_API_SUBSCRIPTION_KEY` and `REACT_APP_API_SUBSCRIPTION_KEY_PARAM` are set to GraphQL request query string for authorization gateway service.
 
 ## Run in docker
 
 ```sh
-docker build -t graphiql
+docker build -t graphiql .
 docker run -it \
     -p 8099:8080 \
-    -e REACT_APP_API_SUBSCRIPTION_KEY=test \
+    -e REACT_APP_DEV_API_SUBSCRIPTION_KEY=key \
+    -e REACT_APP_API_SUBSCRIPTION_KEY=key \
     -e REACT_APP_API_SUBSCRIPTION_KEY_PARAM=digitransit-subscription-key \
      graphiql
 ```

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter as Router, Redirect } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Redirect } from 'react-router-dom';
 
 import GraphiQL from './GraphiQL';
 
@@ -107,7 +107,9 @@ export default class App extends React.Component {
     return (
       <Router basename="/graphiql">
         <GraphiQL configObjs={configs} />
-        <Redirect to="/hsl"/>
+        <Route path="/" exact>
+          <Redirect to="/hsl" />
+        </Route>
       </Router>
     );
   }

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter as Router } from 'react-router-dom';
+import { BrowserRouter as Router, Redirect } from 'react-router-dom';
 
 import GraphiQL from './GraphiQL';
 
@@ -32,7 +32,8 @@ const configs = [
       v2: {
         title: 'HSL (v2 experimental)',
         routerUrl: {
-          dev: buildUrl('dev', VERSION_2, 'hsl')
+          dev: buildUrl('dev', VERSION_2, 'hsl'),
+          prod: buildUrl('prod', VERSION_2, 'hsl')
         }
       }
     }
@@ -50,7 +51,8 @@ const configs = [
       v2: {
         title: 'Waltti (v2 experimental)',
         routerUrl: {
-          dev: buildUrl('dev', VERSION_2, 'waltti')
+          dev: buildUrl('dev', VERSION_2, 'waltti'),
+          prod: buildUrl('prod', VERSION_2, 'waltti')
         }
       }
     }
@@ -80,7 +82,8 @@ const configs = [
       v2: {
         title: 'Finland (v2 experimental)',
         routerUrl: {
-          dev: buildUrl('dev', VERSION_2, 'finland')
+          dev: buildUrl('dev', VERSION_2, 'finland'),
+          prod: buildUrl('prod', VERSION_2, 'finland')
         }
       }
     }
@@ -104,6 +107,7 @@ export default class App extends React.Component {
     return (
       <Router basename="/graphiql">
         <GraphiQL configObjs={configs} />
+        <Redirect to="/hsl"/>
       </Router>
     );
   }

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -13,15 +13,18 @@ const initWindowLocation = (window, url) => {
 };
 
 describe('App', () => {
+
   test('renders basepath without crashing', () => {
     initWindowLocation(window, 'https://localhost/graphiql');
     const div = document.createElement('div');
     ReactDOM.render(<App />, div);
+    ReactDOM.unmountComponentAtNode(div);
   });
 
   test('renders end-point "hsl" without crashing', () => {
     initWindowLocation(window, 'https://localhost/graphiql/hsl?query=%257Bfeeds%257BfeedId%257D%257D');
     const div = document.createElement('div');
     ReactDOM.render(<App />, div);
+    ReactDOM.unmountComponentAtNode(div);
   });
 });

--- a/src/GraphiQL.js
+++ b/src/GraphiQL.js
@@ -191,8 +191,9 @@ const CustomGraphiQLWrapper = ({
   configs,
   config,
   replace,
-  subscriptionKey,
-  subscriptionKeyParam
+  prodSubscriptionKey,
+  subscriptionKeyParam,
+  devSubscriptionKey
 }) => {
   const {
     query,
@@ -237,6 +238,8 @@ const CustomGraphiQLWrapper = ({
     });
   };
 
+  const subscriptionKey = apiType === 'prod' ? prodSubscriptionKey : devSubscriptionKey;
+  
   return (
     <NonFlickeringCustomGraphiQL
       alert={alert}
@@ -263,7 +266,8 @@ const withSubscriptionKey = (Component) => (props) =>
   (
     <Component
       {...props}
-      subscriptionKey={process.env.REACT_APP_API_SUBSCRIPTION_KEY}
+      prodSubscriptionKey={process.env.REACT_APP_API_SUBSCRIPTION_KEY}
+      devSubscriptionKey={process.env.REACT_APP_DEV_API_SUBSCRIPTION_KEY}
       subscriptionKeyParam={process.env.REACT_APP_API_SUBSCRIPTION_KEY_PARAM}
     />
   );
@@ -276,8 +280,9 @@ const GraphiQLRoute = withSubscriptionKey(
       configs,
       config,
       isDefault = false,
-      subscriptionKey = null,
-      subscriptionKeyParam = null
+      prodSubscriptionKey = null,
+      subscriptionKeyParam = null,
+      devSubscriptionKey = null,
     }) => (
       <Route
         path={
@@ -292,8 +297,9 @@ const GraphiQLRoute = withSubscriptionKey(
               replace={history.replace}
               configs={configs}
               config={config}
-              subscriptionKey={subscriptionKey}
+              prodSubscriptionKey={prodSubscriptionKey}
               subscriptionKeyParam={subscriptionKeyParam}
+              devSubscriptionKey={devSubscriptionKey}
             />
           </>
         )}


### PR DESCRIPTION
- Existing parameter, <code>REACT_APP_API_SUBSCRIPTION_KEY</code>, now takes the production subscription key.
- A new environment parameter added for the dev subscription key <code>REACT_APP_DEV_API_SUBSCRIPTION_KEY</code>
- Hsl, waltti and finland v2 (experimental) endpoints enabled for production.
- Redirection to /hsl to avoid app opening to an empty page.

**Notice**: Environment variables need to be correctly configured in the project _digitransit-kubernetes-deploy_ https://github.com/HSLdevcom/digitransit-kubernetes-deploy/blob/master/roles/aks-apply/files/dev/graphiql-dev.yml